### PR TITLE
updating PlaidSuccessMetadata interface to match

### DIFF
--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -4,6 +4,7 @@ export interface PlaidSuccessMetadata {
   account: PlaidAccountObject;
   accounts: Array<PlaidAccountObject>;
   account_id: string;
+  public_token: string;
 }
 
 export interface PlaidOnSuccessArgs {

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -1,7 +1,9 @@
 export interface PlaidSuccessMetadata {
   link_session_id: string;
   institution: PlaidInstitutionObject;
-  account: Array<PlaidAccountObject>;
+  account: PlaidAccountObject;
+  accounts: Array<PlaidAccountObject>;
+  account_id: string;
 }
 
 export interface PlaidOnSuccessArgs {


### PR DESCRIPTION
It looks like the return object from plaid has changed slightly.  These changes reflect what it is now:

<img width="1371" alt="Screenshot 2019-10-02 09 30 25" src="https://user-images.githubusercontent.com/309066/66062974-4bb94980-e4f7-11e9-8598-95491686998e.png">
