### PR TITLE
Added support for accountSubtypes for PlaidConfig

### DIFF
--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -92,4 +92,3 @@ export interface PlaidConfig {
   countryCodes?: string[];
   accountSubtypes?: PlaidAccountTypes
 }
-

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -63,6 +63,20 @@ export interface PlaidEventMetadata {
   timestamp: string;
 }
 
+export enum PlaidCreditAccountSubtypes {
+  CreditCard = 'credit card',
+  PayPal = 'paypal'
+}
+
+export enum PlaidLoanAccountSubtypes {
+  Student = 'student'
+}
+
+export interface PlaidAccountTypes {
+  credit?: Array<PlaidCreditAccountSubtypes>;
+  loan?: Array<PlaidLoanAccountSubtypes>;
+}
+
 export interface PlaidConfig {
   apiVersion?: string;
   clientName?: string;
@@ -76,4 +90,6 @@ export interface PlaidConfig {
   token?: string;
   webhook?: string;
   countryCodes?: string[];
+  accountSubtypes?: PlaidAccountTypes
 }
+


### PR DESCRIPTION
Plaid allows to filter its response through institutions. This PR adds needed field for this action to the PlaidConfig interface.
Details: https://plaid.com/docs/#filtering-institutions-in-link