### PR TITLE
NgxPlaidLinkDirective extracted from NgxPlaidLinkButtonComponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,23 @@ import { NgxPlaidLinkModule } from "ngx-plaid-link";
 })
 export class AppModule {}
 ```
+#### 3a) The easy way, the `ngxPlaidLink` Directives
 
-#### 3a) The easy way, with the provided button
+```html
+<button ngxPlaidLink
+  env="sandbox"
+  publicKey="YOURPUBLICKEY"
+  institution=""
+  [countryCodes]="['US', 'CA', 'GB']"
+  (Success)="onPlaidSuccess($event)"
+  (Exit)="onPlaidExit($event)"
+  (Load)="onPlaidLoad($event)"
+  (Event)="onPlaidEvent($event)"
+  (Click)="onPlaidClick($event)"
+>Link Your Bank Account</button>
+```
+
+#### 3b) The easy way, with the provided button
 
 ```html
 <mr-ngx-plaid-link-button

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -92,4 +92,3 @@ export interface PlaidConfig {
   countryCodes?: string[];
   accountSubtypes?: PlaidAccountTypes
 }
-

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -63,20 +63,6 @@ export interface PlaidEventMetadata {
   timestamp: string;
 }
 
-export enum PlaidCreditAccountSubtypes {
-  CreditCard = 'credit card',
-  PayPal = 'paypal'
-}
-
-export enum PlaidLoanAccountSubtypes {
-  Student = 'student'
-}
-
-export interface PlaidAccountTypes {
-  credit?: Array<PlaidCreditAccountSubtypes>;
-  loan?: Array<PlaidLoanAccountSubtypes>;
-}
-
 export interface PlaidConfig {
   apiVersion?: string;
   clientName?: string;
@@ -90,5 +76,4 @@ export interface PlaidConfig {
   token?: string;
   webhook?: string;
   countryCodes?: string[];
-  accountSubtypes?: PlaidAccountTypes
 }

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -63,6 +63,20 @@ export interface PlaidEventMetadata {
   timestamp: string;
 }
 
+export enum PlaidCreditAccountSubtypes {
+  CreditCard = 'credit card',
+  PayPal = 'paypal'
+}
+
+export enum PlaidLoanAccountSubtypes {
+  Student = 'student'
+}
+
+export interface PlaidAccountTypes {
+  credit?: Array<PlaidCreditAccountSubtypes>;
+  loan?: Array<PlaidLoanAccountSubtypes>;
+}
+
 export interface PlaidConfig {
   apiVersion?: string;
   clientName?: string;
@@ -76,4 +90,6 @@ export interface PlaidConfig {
   token?: string;
   webhook?: string;
   countryCodes?: string[];
+  accountSubtypes?: PlaidAccountTypes
 }
+

--- a/src/lib/ngx-plaid-link.directive.spec.ts
+++ b/src/lib/ngx-plaid-link.directive.spec.ts
@@ -1,0 +1,14 @@
+import { NgxPlaidLinkDirective } from './ngx-plaid-link.directive';
+import { NgxPlaidLinkService } from './ngx-plaid-link.service';
+import { TestBed } from '@angular/core/testing';
+
+describe('NgxPlaidLinkDirective', () => {
+  it('should create an instance', () => {
+    TestBed.configureTestingModule({
+      providers: [NgxPlaidLinkService]
+    });
+
+    const directive = new NgxPlaidLinkDirective(TestBed.get(NgxPlaidLinkService));
+    expect(directive).toBeTruthy();
+  });
+});

--- a/src/lib/ngx-plaid-link.directive.ts
+++ b/src/lib/ngx-plaid-link.directive.ts
@@ -1,0 +1,107 @@
+import { Directive, EventEmitter, HostBinding, HostListener, Input, Output } from '@angular/core';
+import { PlaidLinkHandler } from './ngx-plaid-link-handler';
+import {
+  PlaidErrorMetadata,
+  PlaidErrorObject,
+  PlaidEventMetadata,
+  PlaidOnEventArgs,
+  PlaidOnExitArgs,
+  PlaidOnSuccessArgs,
+  PlaidSuccessMetadata
+} from './interfaces';
+import { NgxPlaidLinkService } from './ngx-plaid-link.service';
+
+function getWindow(): any {
+  return window;
+}
+
+export interface ICustomWindow extends Window {
+  Plaid: {
+    create: Function;
+  };
+}
+
+@Directive({
+  selector: '[ngxPlaidLink]'
+})
+export class NgxPlaidLinkDirective {
+  @Output() Event: EventEmitter<PlaidOnEventArgs> = new EventEmitter();
+  @Output() Click: EventEmitter<any> = new EventEmitter();
+  @Output() Load: EventEmitter<any> = new EventEmitter();
+  @Output() Exit: EventEmitter<PlaidOnExitArgs> = new EventEmitter();
+  @Output() Success: EventEmitter<PlaidOnSuccessArgs> = new EventEmitter();
+
+  @Input() clientName: string;
+  @Input() publicKey: string;
+
+  @HostBinding('disabled') disabledButton: boolean;
+
+  private plaidLinkHandler: PlaidLinkHandler;
+  private defaultProps = {
+    apiVersion: "v2",
+    env: "sandbox",
+    institution: null,
+    token: null,
+    webhook: "",
+    product: ["auth"],
+    countryCodes: ["US"]
+  };
+
+  @Input() apiVersion?: string = this.defaultProps.apiVersion;
+  @Input() env?: string = this.defaultProps.env;
+  @Input() institution?: string = this.defaultProps.institution;
+  @Input() product?: Array<string> = this.defaultProps.product;
+  @Input() token?: string = this.defaultProps.token;
+  @Input() webhook?: string = this.defaultProps.webhook;
+  @Input() countryCodes?: string[] = this.defaultProps.countryCodes;
+
+  constructor(private plaidLinkLoader: NgxPlaidLinkService) {
+    this.disabledButton = true;
+  }
+
+  async ngOnInit() {
+    let handler: PlaidLinkHandler = await this.plaidLinkLoader
+      .createPlaid({
+        env: this.env,
+        key: this.publicKey,
+        product: this.product,
+        apiVersion: "v2",
+        clientName: this.clientName,
+        countryCodes: this.countryCodes,
+        onSuccess: (public_token, metadata) => this.onSuccess(public_token, metadata),
+        onExit: (err, metadata) => this.onExit(err, metadata),
+        onEvent: (eventName, metadata) => this.onEvent(eventName, metadata),
+        onLoad: () => this.onLoad(),
+        token: this.token || null,
+        webhook: this.webhook || null
+      });
+    this.disabledButton = false;
+    this.plaidLinkHandler = handler;
+  }
+
+  public onExit(error: PlaidErrorObject, metadata: PlaidErrorMetadata) {
+    this.Exit.emit({error, metadata});
+  }
+
+  public onEvent(eventName: string, metadata: PlaidEventMetadata) {
+    this.Event.emit({eventName, metadata});
+  }
+
+  public onSuccess(token: string, metadata: PlaidSuccessMetadata) {
+    this.Success.emit({token, metadata});
+  }
+
+  @HostListener('click', ['$event'])
+  onClick($event) {
+    this.Click.emit($event);
+    // Open to a specific institution if necessary;
+    const institution = this.institution || null;
+    if (this.plaidLinkHandler) {
+      this.plaidLinkHandler.open(institution);
+    }
+  }
+
+  public onLoad($event = "link_loaded") {
+    this.Load.emit($event);
+  }
+}

--- a/src/lib/ngx-plaid-link.module.ts
+++ b/src/lib/ngx-plaid-link.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { NgxPlaidLinkButtonComponent } from './ngx-plaid-link-button.component';
 import { NgxPlaidLinkService } from './ngx-plaid-link.service';
+import { NgxPlaidLinkDirective } from './ngx-plaid-link.directive';
 
 @NgModule({
   imports: [
@@ -10,7 +11,7 @@ import { NgxPlaidLinkService } from './ngx-plaid-link.service';
   providers: [
     NgxPlaidLinkService
   ],
-  declarations: [NgxPlaidLinkButtonComponent],
-  exports: [NgxPlaidLinkButtonComponent]
+  declarations: [NgxPlaidLinkButtonComponent, NgxPlaidLinkDirective],
+  exports: [NgxPlaidLinkButtonComponent, NgxPlaidLinkDirective]
 })
 export class NgxPlaidLinkModule { }

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -4,4 +4,5 @@
 
 export * from './lib/ngx-plaid-link.service';
 export * from './lib/ngx-plaid-link-button.component';
+export * from './lib/ngx-plaid-link.directive';
 export * from './lib/ngx-plaid-link.module';


### PR DESCRIPTION
MVC model would dictate that the great functionality you created not be tied to a ButtonComponent.

I was trying to put the ngxPlaidLink onto an Ionic 5 component, and having to use an NgxPlaidLinkButton was an issue, and I didn't want to use the "Less Easy Way" so instead I put the time in to creating the NgxPlaidLinkDirective so that people could add the functionality to any component they wanted.

I made sure that the NgxPlaidLinkButtonComponent would continue to work as is, but the core functionality is now in the Directive