### PR TITLE
Implemented selectAccount functionality to allow users to view a list of accounts through Plaid's modal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ export class ComponentThatImplementsPlaidLink implements AfterViewInit {
     apiVersion: "v2",
     env: "sandbox",
     institution: null,
+    selectAccount: false,
     token: null,
     webhook: "",
     product: ["auth"],
@@ -161,6 +162,7 @@ This is all there in the types, but here they are for convenience.
 | product        | input        | optional          | string[] | ['auth']                      | An array of the names of the products you'd like to authorize. Available options are `transactions`, `auth`, and `identity`.        |
 | publicKey      | input        | required          | string   | null                          | The public key from your Plaid account _Make sure it's the public key and not the private key_                                      |
 | style          | input        | optional          | object   | An object of styles           | An ngStyle object that can be used to apply styles and customize the plaid link button to match your app.                           |
+| selectAccount          | input        | optional          | boolean   | false                          | Setting this to `TRUE` will allow the user to select their bank account from a list through the plaid modal. `FALSE` does not show the account list prompt.                           |
 | token          | input        | optional          | string   | null                          | You can provide a token if you are re-authenticating or updating an item that has previously been linked.                           |
 | webhook        | input        | optional          | string   | null                          | You can provide a webhook for each item that Plaid will send events to.                                                             |
 | Exit           | output       | required          | function | n/a                           | Passes the result from the onExit function to your component                                                                        |

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -73,6 +73,7 @@ export interface PlaidConfig {
   onExit: Function;
   onEvent?: Function;
   product: Array<string>;
+  selectAccount?: boolean;
   token?: string;
   webhook?: string;
   countryCodes?: string[];

--- a/src/lib/ngx-plaid-link-button.component.ts
+++ b/src/lib/ngx-plaid-link-button.component.ts
@@ -18,6 +18,7 @@ function getWindow(): any {
             [env]="env"
             [institution]="institution"
             [product]="product"
+            [selectAccount]="false"
             [token]="token"
             [webhook]="webhook"
             [countryCodes]="countryCodes"
@@ -45,6 +46,7 @@ export class NgxPlaidLinkButtonComponent {
     apiVersion: "v2",
     env: "sandbox",
     institution: null,
+    selectAccount: false,
     token: null,
     webhook: "",
     product: ["auth"],
@@ -75,6 +77,7 @@ export class NgxPlaidLinkButtonComponent {
   @Input() env?: string = this.defaultProps.env;
   @Input() institution?: string = this.defaultProps.institution;
   @Input() product?: Array<string> = this.defaultProps.product;
+  @Input() selectAccount?: boolean = this.defaultProps.selectAccount;
   @Input() token?: string = this.defaultProps.token;
   @Input() webhook?: string = this.defaultProps.webhook;
   @Input() countryCodes?: string[] = this.defaultProps.countryCodes;

--- a/src/lib/ngx-plaid-link-button.component.ts
+++ b/src/lib/ngx-plaid-link-button.component.ts
@@ -18,7 +18,7 @@ function getWindow(): any {
             [env]="env"
             [institution]="institution"
             [product]="product"
-            [selectAccount]="false"
+            [selectAccount]="selectAccount"
             [token]="token"
             [webhook]="webhook"
             [countryCodes]="countryCodes"

--- a/src/lib/ngx-plaid-link.directive.ts
+++ b/src/lib/ngx-plaid-link.directive.ts
@@ -41,6 +41,7 @@ export class NgxPlaidLinkDirective {
     apiVersion: "v2",
     env: "sandbox",
     institution: null,
+    selectAccount: false,
     token: null,
     webhook: "",
     product: ["auth"],
@@ -51,6 +52,7 @@ export class NgxPlaidLinkDirective {
   @Input() env?: string = this.defaultProps.env;
   @Input() institution?: string = this.defaultProps.institution;
   @Input() product?: Array<string> = this.defaultProps.product;
+  @Input() selectAccount?: boolean = this.defaultProps.selectAccount;
   @Input() token?: string = this.defaultProps.token;
   @Input() webhook?: string = this.defaultProps.webhook;
   @Input() countryCodes?: string[] = this.defaultProps.countryCodes;
@@ -72,6 +74,7 @@ export class NgxPlaidLinkDirective {
         onExit: (err, metadata) => this.onExit(err, metadata),
         onEvent: (eventName, metadata) => this.onEvent(eventName, metadata),
         onLoad: () => this.onLoad(),
+        selectAccount: this.selectAccount,
         token: this.token || null,
         webhook: this.webhook || null
       });


### PR DESCRIPTION
First, great work and thank you for making this package! It's extremely useful.

**Pull request:**
I use the `selectAccount` property/functionality in the Plaid modal when not working with Angular in every project that implements Plaid, but the property was missing from this package. I've added the functionality in this PR. I've also updated the README file to reflect the added functionality, it's used the same as any other component property.
_The default value for `selectAccount` is set to `FALSE` because that's how it was working previously._

**Note:**
There are two commits in this PR, the first one is the implementation of `selectAccount` and the second is a bugfix where I entered the wrong value in a component property.

**Example using the new `selectAccount` property:**
```
<mr-ngx-plaid-link-button
  env="sandbox"
  product="auth"
  publicKey="{{ environment.plaid.publicKey }}"
  clientName="SomeCompany LLC"
  [selectAccount]="true"
  [countryCodes]="['US']"
  (Success)="onPlaidSuccess($event)"
  (Event)="onPlaidEvent($event)"
  className="launch-plaid-link-button"
  buttonText="Link Your Bank Account"
></mr-ngx-plaid-link-button>
```