### PR TITLE
feat(export-handler): add ngx-plaid-link-handler to public_api.ts

### DIFF
--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -2,8 +2,9 @@
  * Public API Surface of ngx-plaid-link
  */
 
-export * from './lib/interfaces';
-export * from './lib/ngx-plaid-link.service';
-export * from './lib/ngx-plaid-link-button.component';
-export * from './lib/ngx-plaid-link.directive';
-export * from './lib/ngx-plaid-link.module';
+export * from "./lib/interfaces";
+export * from "./lib/ngx-plaid-link.service";
+export * from "./lib/ngx-plaid-link-button.component";
+export * from "./lib/ngx-plaid-link.directive";
+export * from "./lib/ngx-plaid-link.module";
+export * from "./lib/ngx-plaid-link-handler";


### PR DESCRIPTION
at the moment, it is not possible to use the ngx-plaid-link-handler in our app since it's not exported through public-api.ts.

I just added to the public-api.ts file to make it available.

Is it ok for you?