### PR TITLE
feat(PlaidCondig): add receivedRedirectUri property to PlaidConfig in…

### DIFF
--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -76,4 +76,5 @@ export interface PlaidConfig {
   token?: string;
   webhook?: string;
   countryCodes?: string[];
+  receivedRedirectUri?: string;
 }


### PR DESCRIPTION
add receivedRedirectUri to PlaidConfig which is needed for client-side configuration for Desktop web, mobile web, or React