### PR TITLE
Fix typo: 'instituion' > 'institution'

### DIFF
--- a/projects/ngx-plaid-link/src/lib/interfaces.ts
+++ b/projects/ngx-plaid-link/src/lib/interfaces.ts
@@ -78,7 +78,7 @@ export interface LegacyPlaidConfig {
   onEvent?: Function;
   product?: Array<string>;
   selectAccount?: boolean;
-  instituion?: string;
+  institution?: string;
   token?: string;
   webhook?: string;
   countryCodes?: string[];

--- a/projects/ngx-plaid-link/src/lib/ngx-plaid-link.directive.ts
+++ b/projects/ngx-plaid-link/src/lib/ngx-plaid-link.directive.ts
@@ -78,7 +78,7 @@ export class NgxPlaidLinkDirective {
       apiVersion: 'v2',
       clientName: this.clientName,
       countryCodes: this.countryCodes,
-      instituion: this.institution,
+      institution: this.institution,
       onSuccess: (public_token: string, metadata: any) =>
         this.onSuccess(public_token, metadata),
       onExit: (err: any, metadata: any) => this.onExit(err, metadata),


### PR DESCRIPTION
Simple typo correction