### PR TITLE
Updated docs to show new Plaid token implementation

### DIFF
--- a/projects/ngx-plaid-link/README.md
+++ b/projects/ngx-plaid-link/README.md
@@ -39,10 +39,8 @@ export class AppModule {}
 
 ```html
 <button ngxPlaidLink
-  env="sandbox"
-  publicKey="YOURPUBLICKEY"
-  institution=""
-  [countryCodes]="['US', 'CA', 'GB']"
+   *ngIf="plaidToken"
+  [token]="plaidToken"
   (Success)="onPlaidSuccess($event)"
   (Exit)="onPlaidExit($event)"
   (Load)="onPlaidLoad($event)"
@@ -55,10 +53,8 @@ export class AppModule {}
 
 ```html
 <mr-ngx-plaid-link-button
-  env="sandbox"
-  publicKey="YOURPUBLICKEY"
-  institution=""
-  [countryCodes]="['US', 'CA', 'GB']"
+  *ngIf="plaidToken"
+  [token]="plaidToken"
   (Success)="onPlaidSuccess($event)"
   (Exit)="onPlaidExit($event)"
   (Load)="onPlaidLoad($event)"


### PR DESCRIPTION
I struggled for quite a while to figure out why my token wasn't working in the `public_key` field. Eventually I found this:
![image](https://github.com/mike-roberts/ngx-plaid-link/assets/6846214/bcb39d54-bc6b-4035-ae04-a05383910d7f)

Plaid no longer supports `public_keys`. The library already has functionality for the new token system, but the docs didn't reflect that. I didn't realize this until I looked at the example code and saw that it was being implemented differently in the example than in the docs.

This PR simply updates the docs to reflect the working implementation.